### PR TITLE
Possibly solved issue "Error in grDevices::rgb(red = df, green = df, blue = df, : color intensity NA, not in [0,1]"

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -66,7 +66,7 @@ gg_raster <- function(r, r_type = "RGB", gglayer = F, ...){
     }
     
     # remove NAs
-    na.sel <- is.na(df$val1) & is.na(df$val2) & is.na(df$val3)
+    na.sel <- is.na(df$val1) | is.na(df$val2) | is.na(df$val3)
     if(any(na.sel)) df <- df[!na.sel,]
     
     df$fill <- grDevices::rgb(red = df$val1, green = df$val2, blue = df$val3, maxColorValue = maxColorValue)


### PR DESCRIPTION
Hi, 

I was struggling with the error "Error in grDevices::rgb(red = df, green = df, blue = df, : color intensity NA, not in [0,1]" (reported also in issue #19 by seaCatKim) , i found out that the reason was the line 69 in the plot.R file (in function gg_raster).

Indeed, the line was:

`na.sel <- is.na(df$val1) & is.na(df$val2) & is.na(df$val3)`

but this was actually used to remove rows only when all val1, val2 and val3 were NA, leaving untouched rows where one or two of them were NA, so I changed it into:

`na.sel <- is.na(df$val1) | is.na(df$val2) | is.na(df$val3)`

I don't know if it is the most suitable solution, but it seems to be working.

Best,
Roberto