### PR TITLE
Add USGS tileset options

### DIFF
--- a/R/get_maptypes.R
+++ b/R/get_maptypes.R
@@ -20,6 +20,8 @@
 #' 
 #' \code{"esri"}: Esri (\url{https://www.esri.com/en-us/home})
 #'
+#' \code{"usgs"}: USGS (\url{https://basemap.nationalmap.gov/arcgis/rest/services})
+#' 
 #' @examples 
 #' # for all services
 #' get_maptypes()

--- a/R/internal.R
+++ b/R/internal.R
@@ -174,6 +174,7 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
+          out(" ", type = 1)
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)

--- a/R/internal.R
+++ b/R/internal.R
@@ -169,7 +169,7 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
           # download tiles
           url <- paste0(
             getOption("basemaps.map_api")[[map_service]][[map_type]], tg$zoom, "/", # base URL
-            if(map_service == "esri" || map_service == "usgs") paste0(x[2], "/", x[1]) else paste0(x[1], "/", x[2]), # coordinate order
+            if(map_service == "esri") paste0(x[2], "/", x[1]) else paste0(x[1], "/", x[2]), # coordinate order
             if(any(map_service != "mapbox", all(map_service == "mapbox", map_type == "terrain"))) ".png", # file suffix or not
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not

--- a/R/internal.R
+++ b/R/internal.R
@@ -174,7 +174,7 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
-          out(sprintf("URL: %s", url))
+          out(paste("URL:", url), type = 3)
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)

--- a/R/internal.R
+++ b/R/internal.R
@@ -169,7 +169,7 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
           # download tiles
           url <- paste0(
             getOption("basemaps.map_api")[[map_service]][[map_type]], tg$zoom, "/", # base URL
-            if(map_service == "esri") paste0(x[2], "/", x[1]) else paste0(x[1], "/", x[2]), # coordinate order
+            if(map_service == "esri" || map_service == "usgs") paste0(x[2], "/", x[1]) else paste0(x[1], "/", x[2]), # coordinate order
             if(any(map_service != "mapbox", all(map_service == "mapbox", map_type == "terrain"))) ".png", # file suffix or not
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not

--- a/R/internal.R
+++ b/R/internal.R
@@ -174,7 +174,6 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
-          out(url, type = 1)
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)
@@ -509,7 +508,6 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
       imagery_only = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/",
       imagery_topo = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/",
       shaded_relief = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSShadedReliefOnly/MapServer/tile/",
-      national_map = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSTNMBlank/MapServer/tile/",
       topo = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/"
     )
   ))

--- a/R/internal.R
+++ b/R/internal.R
@@ -174,6 +174,7 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
+          log_info(sprintf("URL: " %s, url))
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)

--- a/R/internal.R
+++ b/R/internal.R
@@ -174,7 +174,6 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
-          out(paste("URL:", url), type = 1)
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)

--- a/R/internal.R
+++ b/R/internal.R
@@ -174,6 +174,7 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
+          print(url)
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)

--- a/R/internal.R
+++ b/R/internal.R
@@ -174,7 +174,6 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
-          print(url)
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)
@@ -502,7 +501,16 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
       world_reference_overlay = "https://services.arcgisonline.com/arcgis/rest/services/Reference/World_Reference_Overlay/MapServer/tile/",
       world_transportation = "https://services.arcgisonline.com/arcgis/rest/services/Reference/World_Transportation/MapServer/tile/",
       delorme_world_base_map = "https://services.arcgisonline.com/arcgis/rest/services/Specialty/DeLorme_World_Base_Map/MapServer/tile/",
-      world_navigation_charts = "https://services.arcgisonline.com/arcgis/rest/services/Specialty/World_Navigation_Charts/MapServer/tile/")
+      world_navigation_charts = "https://services.arcgisonline.com/arcgis/rest/services/Specialty/World_Navigation_Charts/MapServer/tile/"
+    ),
+    usgs = list(
+      hydro_cached = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSHydroCached/MapServer/tile/",
+      imagery_only = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/",
+      imagery_topo = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/",
+      shaded_relief = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSShadedReliefOnly/MapServer/tile/",
+      national_map = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSTNMBlank/MapServer/tile/",
+      topo = "https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/"
+    )
   ))
   if(!dir.exists(getOption("basemaps.defaults")$map_dir)) dir.create(getOption("basemaps.defaults")$map_dir)
   

--- a/R/internal.R
+++ b/R/internal.R
@@ -169,12 +169,12 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
           # download tiles
           url <- paste0(
             getOption("basemaps.map_api")[[map_service]][[map_type]], tg$zoom, "/", # base URL
-            if(map_service == "esri") paste0(x[2], "/", x[1]) else paste0(x[1], "/", x[2]), # coordinate order
+            if(map_service %in% list("esri", "usgs")) paste0(x[2], "/", x[1]) else paste0(x[1], "/", x[2]), # coordinate order
             if(any(map_service != "mapbox", all(map_service == "mapbox", map_type == "terrain"))) ".png", # file suffix or not
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
-          out(paste("URL:", url), type = 3)
+          out(paste("URL:", url), type = 1)
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)

--- a/R/internal.R
+++ b/R/internal.R
@@ -174,7 +174,7 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
-          out(" ", type = 1)
+          out(url, type = 1)
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)

--- a/R/internal.R
+++ b/R/internal.R
@@ -174,7 +174,7 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
-          log_info(sprintf("URL: " %s, url))
+          logger::log_info(sprintf("URL: %s", url))
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)

--- a/R/internal.R
+++ b/R/internal.R
@@ -170,7 +170,7 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
           url <- paste0(
             getOption("basemaps.map_api")[[map_service]][[map_type]], tg$zoom, "/", # base URL
             if(map_service %in% list("esri", "usgs")) paste0(x[2], "/", x[1]) else paste0(x[1], "/", x[2]), # coordinate order
-            if(any(map_service != "mapbox", all(map_service == "mapbox", map_type == "terrain"))) ".png", # file suffix or not
+            if(any(!(map_service %in% list("mapbox", "usgs")), all(map_service == "mapbox", map_type == "terrain"))) ".png", # file suffix or not
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )

--- a/R/internal.R
+++ b/R/internal.R
@@ -174,7 +174,7 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
             if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
             if(map_service == "osm_thunderforest") paste0("?apikey=", map_token) # token or not
           )
-          logger::log_info(sprintf("URL: %s", url))
+          out(sprintf("URL: %s", url))
           
           if(isTRUE(http_error(url))){
             resp <- GET(url)

--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ This table lists all currently implemented map services and map types and indica
 | `usgs` | `imagery_only` | no |
 | `usgs` | `imagery_topo` | no |
 | `usgs` | `shaded_relief` | no |
-| `usgs` | `national_map` | no |
 | `usgs` | `topo` | no |
 
 ## Available functions

--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ This table lists all currently implemented map services and map types and indica
 | `esri` | `world_transportation` | no |
 | `esri` | `delorme_world_base_map` | no |
 | `esri` | `world_navigation_charts` | no |
+| `usgs` | `hydro_cached` | no |
+| `usgs` | `imagery_only` | no |
+| `usgs` | `imagery_topo` | no |
+| `usgs` | `shaded_relief` | no |
+| `usgs` | `national_map` | no |
+| `usgs` | `topo` | no |
 
 ## Available functions
 


### PR DESCRIPTION
Expand `map_service` and `map_type` options to include [U.S. Geological Survey (USGS) tilesets](https://basemap.nationalmap.gov/arcgis/rest/services):
- [USGS Hydro Cached](https://basemap.nationalmap.gov/arcgis/rest/services/USGSHydroCached/MapServer)
- [USGS Imagery Only](https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer)
- [USGS Imagery Topo](https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer)
- [USGS Shaded Relief Only](https://basemap.nationalmap.gov/arcgis/rest/services/USGSShadedReliefOnly/MapServer)

- [USGS Topo](https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer)