### PR TITLE
osm_stamen watercolor file extension fix

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -170,15 +170,16 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
         while(retry$do){
           
           # download tiles
-          url <- paste0(
-            getOption("basemaps.map_api")[[map_service]][[map_type]], tg$zoom, "/", # base URL
-            if(map_service == "esri") paste0(x[2], "/", x[1]) else paste0(x[1], "/", x[2]), # coordinate order
-            if(any(map_service != "mapbox", all(map_service == "mapbox", map_type == "terrain"))) ".png", # file suffix or not
-            if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
-            if(map_service == "osm_thunderforest") paste0("?apikey=", map_token), # token or not
-            if(map_service == "osm_stamen") paste0("?api_key=", map_token), # token or not
-            if(map_service == "osm_stadia") paste0("?api_key=", map_token) # token or not
-          )
+        url <- paste0(
+          getOption("basemaps.map_api")[[map_service]][[map_type]], tg$zoom, "/", # base URL
+          if(map_service == "esri") paste0(x[2], "/", x[1]) else paste0(x[1], "/", x[2]), # coordinate order
+          if(all(map_service == "osm_stamen", map_type == "watercolor")) ".jpg" else 
+            if(any(map_service != "mapbox", map_type != "watercolor", all(map_service == "mapbox", map_type == "terrain"))) ".png", # file suffix or not
+          if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
+          if(map_service == "osm_thunderforest") paste0("?apikey=", map_token), # token or not
+          if(map_service == "osm_stamen") paste0("?api_key=", map_token), # token or not
+          if(map_service == "osm_stadia") paste0("?api_key=", map_token) # token or not
+        )
           
           if(isTRUE(debug_client)) out(paste0("[DEBUG CLIENT] ", url, " ---> ", file), msg = T)
           

--- a/R/internal.R
+++ b/R/internal.R
@@ -173,8 +173,8 @@ out <- function(input, type = 1, ll = NULL, msg = FALSE, sign = "", verbose = ge
         url <- paste0(
           getOption("basemaps.map_api")[[map_service]][[map_type]], tg$zoom, "/", # base URL
           if(map_service == "esri") paste0(x[2], "/", x[1]) else paste0(x[1], "/", x[2]), # coordinate order
-          if(all(map_service == "osm_stamen", map_type == "watercolor")) ".jpg" else 
-            if(any(map_service != "mapbox", map_type != "watercolor", all(map_service == "mapbox", map_type == "terrain"))) ".png", # file suffix or not
+          if(all(map_service == "osm_stamen", map_type == "watercolor")) ".jpg" else # add jpg for watercolor
+            if(any(map_service != "mapbox", map_type != "watercolor", all(map_service == "mapbox", map_type == "terrain"))) ".png", # png file suffix or not
           if(map_service == "mapbox") paste0("?access_token=", map_token), # token or not
           if(map_service == "osm_thunderforest") paste0("?apikey=", map_token), # token or not
           if(map_service == "osm_stamen") paste0("?api_key=", map_token), # token or not


### PR DESCRIPTION
This update fixes the osm_stamen watercolor 404 error by appending `.jpg` instead of `.png` to the URLs as discussed in [Issue 30](https://github.com/16EAGLE/basemaps/issues/30).